### PR TITLE
update professional links generation

### DIFF
--- a/PROTON-OC.nlogo
+++ b/PROTON-OC.nlogo
@@ -771,14 +771,13 @@ to-report interested-in? [ the-job ] ; person reporter
 end
 
 to-report decide-professional-conn-number [ employees ]
-  report ifelse-value (count employees <= 20)[count employees - 1][20]
+  report ifelse-value (count employees <= 20) [ count employees - 1 ] [ 20 ]
 end
 
 to init-professional-links
   ask employers [
     let employees current-employees
     let conn decide-professional-conn-number employees
-    show self
     ask employees [ create-professional-links-with n-of conn other employees ]
   ]
 end

--- a/good queries.txt
+++ b/good queries.txt
@@ -6,6 +6,11 @@
 # flux: all new people born
 count all-persons with [ birth-tick >= 0 ]
 
+# networks
+(do not use on large number of links. With 300K, it crashes Netlogo. Go figure why.)
+map [ a -> list a count links with  [ breed = a ] ] remove-duplicates [ breed ]of links
+map [ a -> list a (count links with  [ breed = a ] / count all-persons) ] remove-duplicates [ breed ] of links
+
 # employment
 
 # employment rate


### PR DESCRIPTION
here's my brief summary:

- there are employers
- each employer develop a position-link to each job it receives at setup
- each job is connected to an employee through a job-link
- each employee working with the same employer gets connected to the other employees (as @mariopaolucci wrote, this increses the total number of professional links when it comes to employers with many jobs)

Current situation:

```
observer> ask employers [ show count position-link-neighbors]
(employer 560): 4
(employer 565): 2
(employer 590): 2
(employer 557): 2
(employer 593): 2
(employer 554): 2
(employer 587): 2
(employer 572): 10
(employer 603): 248
(employer 599): 3
(employer 596): 2
(employer 583): 3
(employer 568): 3
```

As @mariopaolucci noted, the employer with 248 jobs kills the model performances.

### Solution:
we just kill professional connections when a person has more than 20, which is an attempt to simulate a division by departments (note that there shouldn't be silos because we are not connecting groups, but just limiting the number of connections received, so there should be some intergroup connections anyway at the end of the procedure)

```
to init-professional-links
  ask employers [
    let employees current-employees
    let conn ifelse-value (count employees < 20)[count employees - 1][20]
    ask employees [ create-professional-links-with n-of conn other employees ]
  ]
end
```
So now networks should be in the range ~6000 to ~9000 links.

also modified: 

```
to welfare-createjobs [ targets ]
  let the-employer nobody
  if any? targets [
    ask targets [
      let target self
      set the-employer one-of employers
      ask the-employer [
        hatch-jobs 1 [
          create-position-link-with myself
          set label self
          set job-level [ job-level ] of target
          create-job-link-with target
          ask target [
            let employees [ current-employees ] of the-employer
            let conn decide-professional-conn-number employees
            create-professional-links-with n-of conn other employees
          ]
        ]
      ]
    ]
  ]
end
```