### PR TITLE
Networks with orientation need both in-range and in-reverse-range

### DIFF
--- a/PROTON-OC.nlogo
+++ b/PROTON-OC.nlogo
@@ -1334,9 +1334,7 @@ end
 to update-meta-links [ agents ]
   nw:with-context agents (link-set person-links criminal-links) [ ; limit the context to the agents in the radius of interest
     ask agents [
-      ask other (turtle-set nw:turtles-in-radius oc-embeddedness-radius nw:turtles-in-reverse-radius oc-embeddedness-radius) [
-        let due myself
-        show [breed] of links with [ both-ends = (turtle-set myself due)]
+      ask other (turtle-set nw:turtles-in-radius 1 nw:turtles-in-reverse-radius 1) [
         create-meta-link-with myself [ ; if that link already exists, it won't be re-created
           let w 0
           if [ household-link-with other-end ] of myself    != nobody [ set w w + 1 ]
@@ -1930,10 +1928,10 @@ count prisoners
 11
 
 PLOT
-10
-645
-385
-800
+15
+690
+390
+845
 Age distribution
 age
 count
@@ -2439,6 +2437,17 @@ OC-bosses-probability
 1
 NIL
 HORIZONTAL
+
+MONITOR
+270
+635
+385
+680
+NIL
+number-weddings
+17
+1
+11
 
 @#$#@#$#@
 ## WHAT IS IT?


### PR DESCRIPTION
It nearly never happens, but it could with the offspring link that they are different. So we should use `nw:turtles-in-radius 1 nw:turtles-in-reverse-radius 1`