### PR TITLE
Repaired test_generate_households

### DIFF
--- a/mesa/testProton.py
+++ b/mesa/testProton.py
@@ -55,16 +55,13 @@ def test_generate_households():
         other_members = set([x for x in test_family if x != member])
         assert other_members == member.neighbors["household"]
     #3
-    for test_simple_family in m.families[:5]:
+    for test_simple_family in m.families:
         if len(test_simple_family) >= 3 and test_family[0].neighbors["partner"] == test_family[1] and test_family[1].neighbors["partner"]  == test_family[0]:
             assert set(test_simple_family[1:]) == test_simple_family[0].neighbors["household"]
             assert test_simple_family[-1] in test_simple_family[0].neighbors["offspring"]
             assert test_simple_family[-1] in test_simple_family[1].neighbors["offspring"]
-            if type(test_simple_family[2:]) == list:
-                for son in test_simple_family[2:]:
-                    assert son.neighbors["parent"] == set(test_simple_family[:2])
-            else:
-                assert test_simple_family[-1].neighbors["parent"] == set(test_simple_family[:2])
+            for son in test_simple_family[2:]:
+                assert son.neighbors["parent"] == set(test_simple_family[:2])
     #4
     for agent in m.schedule.agents:
         for household in agent.neighbors["household"]:

--- a/mesa/testProton.py
+++ b/mesa/testProton.py
@@ -33,7 +33,7 @@ def test_generate_households():
     2. Take a random household and check if all the members of the household are in the other members' network
     3. Take the first simple family (we're sure it's in the first 5) and check if all the networks work.
     4. wealth must be the same for all members of the household
-    5. nobody should have more than one father and one mather
+    5. nobody should have more than one father and one mother
     """
     m = MesaPROTON_OC()
     m.initial_agents = 1000

--- a/mesa/testProton.py
+++ b/mesa/testProton.py
@@ -55,17 +55,16 @@ def test_generate_households():
         other_members = set([x for x in test_family if x != member])
         assert other_members == member.neighbors["household"]
     #3
-    for test_simple_family in m.families[:3]:
-        if len(test_simple_family) >= 3:
-            break
-    assert set(test_simple_family[1:]) == test_simple_family[0].neighbors["household"]
-    assert test_simple_family[-1] in test_simple_family[0].neighbors["offspring"]
-    assert test_simple_family[-1] in test_simple_family[1].neighbors["offspring"]
-    if type(test_simple_family[2:]) == list:
-        for son in test_simple_family[2:]:
-            assert son.neighbors["parent"] == set(test_simple_family[:2])
-    else:
-        assert test_simple_family[-1].neighbors["parent"] == set(test_simple_family[:2])
+    for test_simple_family in m.families[:5]:
+        if len(test_simple_family) >= 3 and test_family[0].neighbors["partner"] == test_family[1] and test_family[1].neighbors["partner"]  == test_family[0]:
+            assert set(test_simple_family[1:]) == test_simple_family[0].neighbors["household"]
+            assert test_simple_family[-1] in test_simple_family[0].neighbors["offspring"]
+            assert test_simple_family[-1] in test_simple_family[1].neighbors["offspring"]
+            if type(test_simple_family[2:]) == list:
+                for son in test_simple_family[2:]:
+                    assert son.neighbors["parent"] == set(test_simple_family[:2])
+            else:
+                assert test_simple_family[-1].neighbors["parent"] == set(test_simple_family[:2])
     #4
     for agent in m.schedule.agents:
         for household in agent.neighbors["household"]:


### PR DESCRIPTION
Simple families can be of two types: couple or single_parents. This variable was not taken into account in the test, now it is.