### PR TITLE
Fix Partner Net

### DIFF
--- a/mesa/Person.py
+++ b/mesa/Person.py
@@ -65,7 +65,7 @@ class Person(Agent):
         return np.floor((self.m.ticks - self.birth_tick) / 12)
 
         
-    def random_init(self, random_relationships = False):
+    def random_init(self, random_relationships = False, exclude_partner_net = False):
         self.education_level = self.m.rng.choice(range(0,4))
         self.max_education_level = self.education_level
         self.wealth_level = self.m.rng.choice(range(0,4))
@@ -76,7 +76,7 @@ class Person(Agent):
         self.hobby = 0
         self.criminal_tendency = self.m.rng.uniform(0, 1)
         if random_relationships == True:
-            self.random_links()
+            self.random_links(exclude_partner_net)
 
 
     def networks_init(self):
@@ -94,15 +94,20 @@ class Person(Agent):
     def step(self):
             pass
 
-    def random_links(self):
+    def random_links(self, exclude_partner_net=False):
         """
         Caution: Use only in test phase. This function generates blood relations and not, randomly
+        :param exclude_partner: exclude partner network
+        :return: None
         """
-        for net in Person.network_names:
+        networks = Person.network_names.copy()
+        if exclude_partner_net:
+            networks.remove("partner")
+        for net in networks:
             for i in range(0,self.m.rng.integers(0,min(len(Person.persons), 100))):
                 self.neighbors.get(net).add(self.m.rng.choice(Person.persons))
             self.neighbors.get(net).discard(self)
-        pass
+
 
     @staticmethod
     def NumberOfLinks():

--- a/mesa/Person.py
+++ b/mesa/Person.py
@@ -39,7 +39,6 @@ class Person(Agent):
         self.oc_member = False
         self.cached_oc_embeddedness = 0
         self.oc_embeddedness_fresh = 0
-        self.partner = None       # the person's significant other
         self.retired = False
         self.number_of_children = 0
         self.facilitator = 0
@@ -90,7 +89,7 @@ class Person(Agent):
         return extra.find_neighb(netname, dist, set(), {self}) - {self}
     
     def isneighbor(self, other):
-        return any([other in self.neighbors[x] for x in Person.network_names]) or self.partner == other
+        return any([other in self.neighbors[x] for x in Person.network_names])
 
     def step(self):
             pass
@@ -188,7 +187,7 @@ class Person(Agent):
         return self.age() >= low and self.age() < high
     
     def family(self): # maybe add self?
-        return self.neighbors.get("sibling").union(self.neighbors.get("offspring")).union(set(self.partner) if self.partner else set())
+        return self.neighbors.get("sibling").union(self.neighbors.get("offspring")).union(self.neighbors.get("partner"))
     
     def potential_friends(self):
         return self.family().union(self.neighbors.get("school")).union(self.neighbors.get("professional")).difference(self.neighbors.get("friendship")) #minus self.. needed?
@@ -233,6 +232,19 @@ class Person(Agent):
             self.potential_school = [x for x in self.m.schools if x.diploma_level == level]
             self.my_school = self.m.rng.choice(self.potential_school)
         self.my_school.my_students.add(self)
+
+    def get_link_list(self, net_name):
+        """
+        Given the name of a network, this method returns a list of agents within the network.
+        If the network is empty, it returns an empty list.
+        :param net_name: str, the network name
+        :return: list, return an empty list if the network is empty
+        """
+        agent_net = self.neighbors.get(net_name)
+        if len(agent_net) > 0:
+            return list(agent_net)
+        else:
+            return []
 
 
 

--- a/mesa/mesaPROTON_OC.py
+++ b/mesa/mesaPROTON_OC.py
@@ -115,11 +115,11 @@ class MesaPROTON_OC(Model):
         # self.running = True
         # self.datacollector.collect(self)
 
-    def create_agents(self, random_relationships=False):
+    def create_agents(self, random_relationships=False, exclude_partner_net=False):
         for i_agent in range(0, self.initial_agents):
             i_agent = Person(self)
             self.schedule.add(i_agent)
-            i_agent.random_init(random_relationships)
+            i_agent.random_init(random_relationships, exclude_partner_net)
 
     def step(self):
         self.schedule.step()
@@ -193,7 +193,7 @@ class MesaPROTON_OC(Model):
     def wedding(self):
         corrected_weddings_mean = (self.number_weddings_mean * len(self.schedule.agents) / 1000) / 12
         num_wedding_this_month = self.rng.poisson(corrected_weddings_mean)  # if num-wedding-this-month < 0 [ set num-wedding-this-month 0 ] ???
-        maritable = [x for x in self.schedule.agents if x.age() > 25 and x.age() < 55 and x.neighbors.get("partner")]
+        maritable = [x for x in self.schedule.agents if x.age() > 25 and x.age() < 55 and not x.neighbors.get("partner")]
         print("marit size: " + str(len(maritable)))
         while num_wedding_this_month > 0 and len(maritable) > 1:
             ego = self.rng.choice(maritable)
@@ -715,10 +715,10 @@ def conclude_wedding(ego, partner):
     for x in [ego, partner]:
         for y in x.neighbors["household"]:
             y.neighbors["household"].discard(x)  # should be remove(x) once we finish tests
-    ego.neighbors["household"] = {partner}
-    partner.neighbors["household"] = {ego}
-    ego.neighbors.get("partner").add(partner)
-    partner.neighbors.get("partner").add(ego)
+    ego.neighbors["household"].add(partner)
+    partner.neighbors["household"].add(ego)
+    ego.neighbors["partner"].add(partner)
+    partner.neighbors["partner"].add(ego)
 staticmethod(conclude_wedding)
 
 

--- a/mesa/mesaPROTON_OC.py
+++ b/mesa/mesaPROTON_OC.py
@@ -193,7 +193,7 @@ class MesaPROTON_OC(Model):
     def wedding(self):
         corrected_weddings_mean = (self.number_weddings_mean * len(self.schedule.agents) / 1000) / 12
         num_wedding_this_month = self.rng.poisson(corrected_weddings_mean)  # if num-wedding-this-month < 0 [ set num-wedding-this-month 0 ] ???
-        maritable = [x for x in self.schedule.agents if x.age() > 25 and x.age() < 55 and x.neigbhors.get("partner")]
+        maritable = [x for x in self.schedule.agents if x.age() > 25 and x.age() < 55 and x.neighbors.get("partner")]
         print("marit size: " + str(len(maritable)))
         while num_wedding_this_month > 0 and len(maritable) > 1:
             ego = self.rng.choice(maritable)

--- a/mesa/testProton.py
+++ b/mesa/testProton.py
@@ -78,12 +78,12 @@ def test_generate_households():
 
 def test_weddings():
     m = MesaPROTON_OC()
-    m.initial_agents = 1000
+    m.initial_agents = 500
     m.create_agents(random_relationships=True, exclude_partner_net=True)
     print(len(m.schedule.agents) - len(pp.Person.persons))
     print(m.number_weddings)
     m.number_weddings_mean = 100
-    for i in range(1, 5):
+    for i in range(1, 2):
         m.wedding()
     # print(Person.NumberOfLinks()-l)
     for agent in m.schedule.agents:

--- a/mesa/testProton.py
+++ b/mesa/testProton.py
@@ -78,6 +78,7 @@ def test_generate_households():
 
 def test_weddings():
     m = MesaPROTON_OC()
+    m.initial_agents = 1000
     m.create_agents(random_relationships=True, exclude_partner_net=True)
     print(len(m.schedule.agents) - len(pp.Person.persons))
     print(m.number_weddings)

--- a/mesa/testProton.py
+++ b/mesa/testProton.py
@@ -88,7 +88,6 @@ def test_weddings():
     for agent in m.schedule.agents:
         if agent.get_link_list("partner"):
             assert agent.get_link_list("partner")[0].get_link_list("partner")[0] == agent
-    #assert len([x for x in m.schedule.agents if x.get_link_list("partner") and x.get_link_list("partner")[0].get_link_list("partner")[0] != x]) == 0
     assert m.number_weddings == len([x for x in m.schedule.agents if x.get_link_list("partner")]) / 2
     assert m.number_weddings > 0
     # coherent state of weddings

--- a/mesa/testProton.py
+++ b/mesa/testProton.py
@@ -78,15 +78,18 @@ def test_generate_households():
 
 def test_weddings():
     m = MesaPROTON_OC()
-    m.create_agents(random_relationships=True)
+    m.create_agents(random_relationships=True, exclude_partner_net=True)
     print(len(m.schedule.agents) - len(pp.Person.persons))
     print(m.number_weddings)
     m.number_weddings_mean = 100
     for i in range(1, 5):
         m.wedding()
     # print(Person.NumberOfLinks()-l)
-    assert len([x for x in m.schedule.agents if x.partner and x.partner.partner != x]) == 0
-    assert m.number_weddings == len([x for x in m.schedule.agents if x.partner]) / 2
+    for agent in m.schedule.agents:
+        if agent.get_link_list("partner"):
+            assert agent.get_link_list("partner")[0].get_link_list("partner")[0] == agent
+    #assert len([x for x in m.schedule.agents if x.get_link_list("partner") and x.get_link_list("partner")[0].get_link_list("partner")[0] != x]) == 0
+    assert m.number_weddings == len([x for x in m.schedule.agents if x.get_link_list("partner")]) / 2
     assert m.number_weddings > 0
     # coherent state of weddings
 


### PR DESCRIPTION
This pull-request fixes issue (close #176 ). From now on "partner" networks are managed like other networks to maintain consistency. A new useful method (get_link_list) has been added to Person class and the tests have been adjusted to keep them working even with the new network architecture. It is not possible to test marriages by maintaining random networks, for this reason an argument has been added to exclude partners.