### PR TITLE
Fixed bugs regarding the attribution of education levels

### DIFF
--- a/PROTON-OC.nlogo
+++ b/PROTON-OC.nlogo
@@ -934,7 +934,7 @@ end
 to limit-education-by-age ; person command
   foreach reverse sort table:keys education-levels [ i ->
     let max-age first but-first table:get education-levels i
-    if age < max-age [ set education-level i - 1 ]
+    if age <= max-age or education-level > max-education-level [ set education-level i - 1 ]
   ]
 end
 
@@ -1093,7 +1093,7 @@ to graduate-and-enter-jobmarket
       leave-school
       set education-level school-education-level
       ifelse table:has-key? education-levels (school-education-level + 1) and
-      (school-education-level + 1 < max-education-level)
+      (school-education-level + 1 <= max-education-level)
       [
         enroll-to-school (school-education-level + 1)
       ] [ ; otherwise, get a job level compatible with my education. Find-jobs will then try to assign the job. This includes the neet-check.

--- a/proton-oc-tests/build.sbt
+++ b/proton-oc-tests/build.sbt
@@ -11,7 +11,7 @@ resolvers += Resolver.bintrayRepo("netlogo", "NetLogo-JVM")
 
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.0.5" % Test,
-  "org.nlogo" % "netlogo" % "6.0.4" % Test
+  "org.nlogo" % "netlogo" % "6.1.1" % Test
 )
 
 lazy val downloadFromZip = taskKey[Unit]("Download zipped extensions and extract them to ./extensions")

--- a/proton-oc-tests/src/test/scala/it/cnr/istc/labss/proton/oc/tests/OCJobTest.scala
+++ b/proton-oc-tests/src/test/scala/it/cnr/istc/labss/proton/oc/tests/OCJobTest.scala
@@ -16,7 +16,7 @@ class OCJobTest extends OCModelSuite {
       println(fid)
       ws.cmd("go")
       // no minors working
-      ws.rpt("any? persons with [ my-job != nobody and age < 18 ] ") shouldBe false
+      ws.rpt("any? persons with [ my-job != nobody and age <= 16 ] ") shouldBe false
       // unemployed stay so
       ws.rpt("any? persons with [ (job-level = 1 or job-level = 0) and my-job != nobody ] ") shouldBe false
       // job levels are coherent     


### PR DESCRIPTION
This pull close #200 and #201. In addition, the testing file that kept an error by entering the right version of netlogo has been updated. 

EDIT: I noticed that the test failed again, problems are solved now but I also found a small consistency problem. In the setup the find-job procedure acts on agents 16 years old or older while in the "go" procedure, the same function (find-job) acts on agents older than 18 years. is it intentional or not?