### PR TITLE
Command-line interface and other minor changes

### DIFF
--- a/mesa/model.py
+++ b/mesa/model.py
@@ -203,7 +203,7 @@ class ProtonOC(Model):
                                 'number_offspring_recruited_this_tick', 'number_crimes',
                                 'crime_multiplier', 'kids_intervention_counter',
                                 'big_crime_from_small_fish', 'arrest_rate', 'migration_on',
-                                'num_persons',
+                                'initial_agents',
                                 'intervention', 'max_accomplice_radius', 'number_arrests_per_year',
                                 'ticks_per_year', 'num_ticks', 'tick', 'ticks_between_intervention',
                                 'intervention_start', 'intervention_end', 'num_oc_persons',
@@ -1638,8 +1638,8 @@ class ProtonOC(Model):
         else:
             map_attr = {"education_rate": "education_modifier",
                         "data_folder": "city",
-                        "[num_oc_persons]": "num_oc_persons"}
-            self.override_xml_active = True
+                        "[num_oc_persons]": "num_oc_persons",
+                        "num_persons": "initial_agents"}
             mydoc = minidom.parse(xml_file)
             parameters = mydoc.getElementsByTagName('enumeratedValueSet')
             ticks = mydoc.getElementsByTagName('timeLimit')[0].attributes['steps'].value

--- a/mesa/model.py
+++ b/mesa/model.py
@@ -45,7 +45,7 @@ class ProtonOC(Model):
     Developed by LABSS-CNR for the PROTON project, https://www.projectproton.eu
     """
 
-    def __init__(self, seed: int = int(time.time())) -> None:
+    def __init__(self, seed: int = os.urandom(3)[0]) -> None:
         super().__init__(seed=seed)
         self.seed: int = seed
         self.rng: np.random.default_rng = default_rng(seed)
@@ -1605,7 +1605,7 @@ class ProtonOC(Model):
             self.schedule.remove(agent)
             del agent
 
-    def save_data(self, save_dir: str, name: str, save_mode: str = "feather") -> None:
+    def save_data(self, save_dir: str, name: str, save_mode: str = "pickle") -> None:
         """
         This creates a new folder named name in the save_dir location and generates
         two files:agents.xxx related to historical data of all agents and model.xxx
@@ -1613,7 +1613,7 @@ class ProtonOC(Model):
         "feather")
         :param save_dir: str, location
         :param name: str, run name
-        :param save_mode: str, can be either "cvs" or "feather"
+        :param save_mode: str, can be either "pickle" or "feather"
         :return: None
         """
         new_dir = os.path.join(save_dir, name)
@@ -1623,32 +1623,35 @@ class ProtonOC(Model):
         if save_mode == "feather":
             agent_data.to_feather(os.path.join(new_dir, "agents" + ".feather"))
             model_data.to_feather(os.path.join(new_dir, "model" + ".feather"))
-        elif save_mode == "csv":
-            agent_data.to_csv(os.path.join(new_dir, "agents" + ".csv"))
-            model_data.to_csv(os.path.join(new_dir, "model" + ".csv"))
+        elif save_mode == "pickle":
+            agent_data.to_pickle(os.path.join(new_dir, "agents" + ".pickle"))
+            model_data.to_pickle(os.path.join(new_dir, "model" + ".pickle"))
 
-    def override_xml(self, xml_file: str) -> None:
+    def override_xml(self, xml_file: Union[str, None]) -> None:
         """
         This function override model parameters based on xml file.
         :param xml_file: str, xml path
         :return: None
         """
-        map_attr = {"education_rate": "education_modifier",
-                    "data_folder": "city",
-                    "[num_oc_persons]": "num_oc_persons"}
-        self.override_xml_active = True
-        mydoc = minidom.parse(xml_file)
-        parameters = mydoc.getElementsByTagName('enumeratedValueSet')
-        ticks = mydoc.getElementsByTagName('timeLimit')[0].attributes['steps'].value
-        setattr(self, "num_ticks", extra.standardize_value(ticks))
-        for par in parameters:
-            attribute = par.attributes['variable'].value.replace("-", "_").replace("?", "").lower()
-            if attribute == "output" or attribute == "oc_members_scrutinize":
-                continue
-            if attribute in map_attr:
-                attribute = map_attr[attribute]
-            value = par.getElementsByTagName("value")[0].attributes["value"].value
-            setattr(self, attribute, extra.standardize_value(value))
+        if xml_file is None:
+            pass
+        else:
+            map_attr = {"education_rate": "education_modifier",
+                        "data_folder": "city",
+                        "[num_oc_persons]": "num_oc_persons"}
+            self.override_xml_active = True
+            mydoc = minidom.parse(xml_file)
+            parameters = mydoc.getElementsByTagName('enumeratedValueSet')
+            ticks = mydoc.getElementsByTagName('timeLimit')[0].attributes['steps'].value
+            setattr(self, "num_ticks", extra.standardize_value(ticks))
+            for par in parameters:
+                attribute = par.attributes['variable'].value.replace("-", "_").replace("?", "").lower()
+                if attribute == "output" or attribute == "oc_members_scrutinize":
+                    continue
+                if attribute in map_attr:
+                    attribute = map_attr[attribute]
+                value = par.getElementsByTagName("value")[0].attributes["value"].value
+                setattr(self, attribute, extra.standardize_value(value))
 
 
 if __name__ == "__main__":

--- a/mesa/run.py
+++ b/mesa/run.py
@@ -23,7 +23,8 @@ class BaseMode:
         """
         self._single_run(None, self.save_path, self.name)
 
-    def _single_run(self, loc_xml: Union[str, None], save_dir: str, name: str) -> None:
+    def _single_run(self, loc_xml: Union[str, None], save_dir: str, name: str, verbose=True) -> \
+            None:
         """
         This instantiates a model, performs a parameter override (if necessary),
         runs a simulation, and saves the data.
@@ -34,7 +35,7 @@ class BaseMode:
         """
         model = ProtonOC()
         model.override_xml(loc_xml)
-        model.run(verbose=False)
+        model.run(verbose=verbose)
         model.save_data(save_dir=save_dir, name=name)
 
 
@@ -114,7 +115,8 @@ class XmlMode(BaseMode):
         """
         processes = list()
         for file, name in zip(self.files, self.filenames):
-            p = multiprocessing.Process(target=self._single_run, args=(file, self.save_path, name))
+            p = multiprocessing.Process(target=self._single_run, args=(file, self.save_path,
+                                                                       name, False))
             processes.append(p)
             p.start()
         for process in processes:
@@ -127,7 +129,7 @@ class XmlMode(BaseMode):
         :return: None
         """
         for file, name in zip(self.files, self.filenames):
-            self._single_run(file, self.save_path, name)
+            self._single_run(file, self.save_path, name, True)
 
 
 @click.group(help="PROTON-OC command line interface")

--- a/mesa/run.py
+++ b/mesa/run.py
@@ -22,6 +22,7 @@ class BaseMode:
         :return: None
         """
         self._single_run(None, self.save_path, self.name)
+        click.echo(click.style("Done!", fg="red"))
 
     def _single_run(self, loc_xml: Union[str, None], save_dir: str, name: str, verbose=True) -> \
             None:
@@ -84,8 +85,10 @@ class XmlMode(BaseMode):
                 self.run_parallel()
             else:
                 self.run_sequential()
+            click.echo(click.style("Done!", fg="red"))
         else:
             click.echo(click.style("\nAborted!", fg="red"))
+
 
     def read_repetitions(self, xml: str) -> int:
         """

--- a/mesa/run.py
+++ b/mesa/run.py
@@ -1,0 +1,169 @@
+from typing import Union, List
+import click
+from model import ProtonOC
+import os
+from xml.dom import minidom
+from collections import Counter
+import multiprocessing
+import time
+
+
+class BaseMode:
+    """
+    Base mode class
+    """
+    def __init__(self, save_path: str, name: str):
+        self.save_path: str = save_path
+        self.name: str = name
+
+    def run(self) -> None:
+        """
+        Simple run function
+        :return: None
+        """
+        self._single_run(None, self.save_path, self.name)
+
+    def _single_run(self, loc_xml: Union[str, None], save_dir: str, name: str) -> None:
+        """
+        This instantiates a model, performs a parameter override (if necessary),
+        runs a simulation, and saves the data.
+        :param loc_xml: if it is a valid string it performs a parameter override from an xml file
+        :param save_dir: directory where the results are saved
+        :param name: run name
+        :return: None
+        """
+        model = ProtonOC()
+        model.override_xml(loc_xml)
+        model.run(verbose=False)
+        model.save_data(save_dir=save_dir, name=name)
+
+
+class XmlMode(BaseMode):
+    """
+    Xml mode class
+    """
+    def __init__(self, xml_path: str, save_path: str, parallel: bool) -> None:
+        super().__init__(save_path=save_path, name="None")
+        self.files = list()
+        self.parallel = parallel
+        self.xml_path = xml_path
+        self.detect_file()
+        click.echo(click.style("Saving data in: " + self.save_path, bold=True, fg="red"))
+        self.filenames = self.get_file_names(self.files)
+
+    def detect_file(self):
+        if os.path.isfile(self.xml_path):
+            if self.xml_path[-3:] == "xml":
+                runs = self.read_repetitions(self.xml_path)
+                self.setup_repetitions(self.xml_path, runs)
+            else:
+                click.ClickException(
+                    click.style(self.xml_path + " is not a valid xml file", fg="red"))
+        else:
+            for filename in os.scandir(self.xml_path):
+                if filename.path.endswith('.xml'):
+                    runs = self.read_repetitions(filename.path)
+                    self.setup_repetitions(filename.path, runs)
+
+    def setup_repetitions(self, path, runs):
+        for repetition in range(runs):
+            self.files.append(path)
+        click.echo(click.style(str(runs) + " runs -> " + os.path.basename(
+            path), fg="blue"))
+
+    def run(self) -> None:
+        """
+        Performs multiple runs
+        :return: None
+        """
+        cmd = click.prompt(click.style("\nConfirm [y/n]", fg="red", blink=True, bold=True),
+                           type=str)
+        if cmd == "y":
+            if self.parallel:
+                self.run_parallel()
+            else:
+                self.run_sequential()
+        else:
+            click.echo(click.style("\nAborted!", fg="red"))
+
+    def read_repetitions(self, xml: str) -> int:
+        """
+        Given an xml file path extracts and returns the number of runs.
+        :param xml: str, a valid xml file path
+        :return: int, the number of runs
+        """
+        return int(minidom.parse(xml).getElementsByTagName('experiment')[0].attributes['repetitions'].value)
+
+    def get_file_names(self, files: List[str]) -> List[str]:
+        """
+        Given a list of xml files extracts the filename and return a list.
+        :param files: a list of valid xml file paths
+        :return: List, a list of filenames
+        """
+        rep = Counter(files)
+        names = list()
+        for key in rep:
+            for value in range(rep[key]):
+                names.append(os.path.basename(key)[:-4] + "_run_" + str(value + 1))
+        return names
+
+    def run_parallel(self) -> None:
+        """
+        Based on the self.files attribute runs multiple parallel simulations and saves the results.
+        :return: None
+        """
+        processes = list()
+        for file, name in zip(self.files, self.filenames):
+            p = multiprocessing.Process(target=self._single_run, args=(file, self.save_path, name))
+            processes.append(p)
+            p.start()
+        for process in processes:
+            process.join()
+
+    def run_sequential(self):
+        """
+        Based on the self.files attribute runs multiple sequential simulations and saves the
+        results
+        :return: None
+        """
+        for file, name in zip(self.files, self.filenames):
+            self._single_run(file, self.save_path, name)
+
+
+@click.group(help="PROTON-OC command line interface")
+def mode():
+    pass
+
+
+@click.command(name="base", help=click.style("Runs a simulation with baseline parameters and "
+                                             "saves results."))
+@click.argument('save_path', type=click.Path(exists=True))
+@click.option("--name", "--n", nargs=1, type=str, default="proton_oc_baseline_" + str(time.localtime().tm_hour) + "_" + str(
+    time.localtime().tm_min))
+def base_mode(save_path, name):
+    mode = BaseMode(save_path, name)
+    mode.run()
+
+
+@click.command(name="xml", help=click.style("Performs multiple simulations based on one or more "
+                                            "xml files and saves results."))
+@click.argument('xml_path', type=click.Path(exists=True))
+@click.argument('save_path', type=click.Path(exists=True))
+@click.option("--p", "--parallel", is_flag=True)
+def xml_mode(save_path, xml_path, p):
+    mode = XmlMode(xml_path, save_path, p)
+    mode.run()
+
+
+@click.command(name="info")
+def info():
+    click.echo("Simulation of recruitment to terrorism \n"
+               "Developed by LABSS-CNR for the PROTON project, https://www.projectproton.eu/")
+
+
+mode.add_command(base_mode)
+mode.add_command(xml_mode)
+mode.add_command(info)
+
+if __name__ == "__main__":
+    mode()


### PR DESCRIPTION
### Command-line interface:
A new run.py file has been added.  This manages the execution of the model through a command line interface. This module uses the clik package which is already a dependency of mesa so, nothing new to install! 

**Usage:**
There are currently two usage modes: 
1. **base mode**,  run a simulation with baseline parameters and saves results. 
    TRY: `python run.py base YOUR_SAVE_PATH --name YOUR_SAVE_NAME`
2. **xml mode**, performs multiple simulations based on one or more xml files and saves results, takes as argument a folder or a single xml file, if folder detects all xml files inside. the` --p` or `--parallel` option performs multiple simulations in parallel.
   TRY: `python run.py xml YOUR_XML_LOCATION YOUR_SAVE_PATH --p`
In the future when proton-oc will be distributed as a package the cli can be started with a simple command (e.g. `proton-oc`) from any location.

For more options just invoke help: `python run.py --help` or `python run.py xml --help` or` python run.py base --help`
Tested on Ubuntu 20.09 and windows.

### Other minor changes:
1. Changed seed generator with os.urandom()
2. Changed default save method to pickle